### PR TITLE
Fix bugs found (broken links and redundant information) in few pages

### DIFF
--- a/intro/webhook_docs_intro.md
+++ b/intro/webhook_docs_intro.md
@@ -4,14 +4,14 @@
 
 - [Introduction](#introduction)
 - [Concepts](#concepts)
-    - [An example](#anexample)
-- [Your first webhook](#yourfirstwebhook)
-    - [The challenge request](#thechallengerequest)
-    - [Testing with ngrok](#testingwithngrok)
-- [Create an integration](#creatinganintegration)
-- [Registering the webhook](#registeringthewebhook)
-- [Receiving events](#receivingevents)
-- [Authenticating events](#authenticatingevents)
+    - [An example](#an-example)
+- [Your first webhook](#your-first-webhook)
+    - [The challenge request](#the-challenge-request)
+    - [Testing with ngrok](#testing-with-ngrok)
+- [Creating an integration](#creating-an-integration)
+- [Registering the webhook](#registering-the-webhook)
+- [Receiving events](#receiving-events)
+- [Authenticating events](#authenticating-events)
 
 ## Introduction
 

--- a/using/aem-event-setup.md
+++ b/using/aem-event-setup.md
@@ -332,7 +332,6 @@ Once you have your webhook ready, use the [Adobe I/O Console](https://adobe.io/c
 
       ![Integration health check](../img/events_aem_26.png "Integration health check")
 
-Note: Once you have registered your webhook, responses will include a [status](https://github.com/adobeio/adobeio-events-documentation/blob/master/Webhook_docs_intro.md#org85f36da) field to show if it is ```VERIFIED```.
 
 ### Perform a webhook health check
 

--- a/using/aem-event-setup.md
+++ b/using/aem-event-setup.md
@@ -19,8 +19,8 @@ These instructions describe how to set up Adobe Experience Manager (AEM) for Ado
 
 Before setting up and using AEM with Adobe I/O, you will need to do the following:
 
-1. [Obtain authorization](#obtainauthorization)
-2. [Register an AEM event consumer app](#registeranaemeventconsumerapp)
+1. [Obtain authorization](#obtain-authorization)
+2. [Register an AEM event consumer app](#register-an-aem-event-consumer-app)
 
 ### Obtain authorization
 
@@ -34,7 +34,7 @@ To complete this solution, you will need authorization to use the following serv
 
 You will need to register an AEM event consumer app, such as a webhook, to see responses to AEM changes.
 These instructions include steps for setting up a webhook that is able to accept
-and reply to a [challenge HTTP request](../intro/webhook_docs_intro.md##thechallengerequest) parameter sent by Adobe I/O Events.
+and reply to a [challenge HTTP request](../intro/webhook_docs_intro.md##the-challenge-request) parameter sent by Adobe I/O Events.
 For more information on understanding and working with webhooks,
 see the [Introduction to Adobe I/O Events Webhooks](../intro/webhook_docs_intro.md).
 
@@ -42,8 +42,8 @@ see the [Introduction to Adobe I/O Events Webhooks](../intro/webhook_docs_intro.
 
 To set up AEM for Adobe I/O Events:
 
-1. [Install the AEM event proxy package](#installtheaemeventproxypackage)
-2. [Configure OAuth and IMS authentication](#configureoauthandimsauthentication)
+1. [Install the AEM event proxy package](#install-the-aem-event-proxy-package)
+   1. [Configure OAuth and IMS authentication](#configure-oauth-and-ims-authentication)
 
 ### Install the AEM event proxy package
 
@@ -94,9 +94,9 @@ For more information, see AEM [User, Group and Access Rights Administration](htt
 
 To configure OAuth and IMS authentication:
 
-1. [Create a certificate and keystore](#createacertificateandkeystore)
-2. [Add the keystore to the AEM eventproxy-service user group](#addthekeystoretotheaemeventproxyserviceusergroup)
-3. [Configure the AEM Link Externalizer](#configuretheaemlinkexternalizer)
+1. [Create a certificate and keystore](#create-a-certificate-and-keystore)
+2. [Add the certificate into the AEM eventproxy-service user's keystore](#Add-the-certificate-into-the-AEM-eventproxy-service-userrsquos-keystore)
+3. [Configure the AEM Link Externalizer](#configure-the-aem-link-externalizer)
 
 #### Create a certificate and keystore
 
@@ -176,10 +176,10 @@ To configure AEM Link Externalizer:
 
 Use Adobe I/O to do the following:
 
-1. [Create an Adobe I/O Console integration](#createanadobeioconsoleintegration)
-2. [Configure Adobe I/O Events as a cloud service in AEM](#configureadobeioeventsasacloudserviceinaem)
-3. [Perform an AEM health and configuration check](#performanaemhealthandconfigurationcheck)
-4. [Register the AEM event consumer app](#registertheaemeventconsumerapp)
+1. [Create an Adobe I/O Console integration](#Create-an-Adobe-IO-Console-integration)
+2. [Configure Adobe I/O Events as a cloud service in AEM](#AEM-Adobe-IO-Events-configuration)
+3. [Perform an AEM health and configuration check](#Perform-AEM-health-check)
+4. [Register the AEM event consumer app](#Register-the-AEM-event-consumer-app)
 
 ### Create an Adobe I/O Console integration
 
@@ -304,9 +304,9 @@ module.exports = Webtask.fromExpress(app);
 
 You can watch the solution work by testing your integration. To do this:
 
-1. [Register your webhook with the Adobe I/O Console](#registeryourwebhookwiththeadobeioconsole)
-2. [Perform a webhook health check](#performawebhookhealthcheck)
-3. [Optional: Adobe I/O Events OSGI to XDM event mapping configurations](#adobeioeventsosgitoxdmeventmappingconfigurations)
+1. [Register your webhook with the Adobe I/O Console](#Register-your-webhook-with-the-Adobe-IO-Console)
+2. [Perform a webhook health check](#Perform-a-webhook-health-check)
+3. [Optional: Adobe I/O Events OSGI to XDM event mapping configurations](#Adobe-IO-Events-OSGI-to-XDM-event-mapping-configurations)
 
 ### Register your webhook with the Adobe I/O Console
 
@@ -318,7 +318,7 @@ Once you have your webhook ready, use the [Adobe I/O Console](https://adobe.io/c
 
       ![Receive near real-time events](../img/events_aem_24.png "Receive near real-time events")
 
-3. Select the AEM Link Externalizer base URL that you [previously specified](#configuretheaemlinkexternalizer) and then select **Continue**.
+3. Select the AEM Link Externalizer base URL that you [previously specified](#Configure-the-AEM-Link-Externalizer) and then select **Continue**.
 
       ![AEM Externalizer base URL on Marketing Cloud](../img/events_aem_25.png "AEM Externalizer base URL on Marketing Cloud")
 

--- a/using/analytics-triggers-event-setup.md
+++ b/using/analytics-triggers-event-setup.md
@@ -5,9 +5,9 @@
 These instructions describe how to use Adobe Analytics triggers to notify you of Adobe I/O events, including the behavior of your site&rsquo;s users. Follow the instructions below to try the solution yourself.
 
 - [Introduction](#introduction)
-- [Set up products](#setupproducts)
-- [Use Adobe I/O](#useadobeio)
-- [Watch the solution work](#watchthesolutionwork)
+- [Set up products](#set-up-products)
+- [Use Adobe I/O](#use-adobe-io)
+- [Watch the solution work](#watch-the-solution-work)
 
 **Resources**
 - [Debugging](../support/debug.md)
@@ -24,8 +24,8 @@ For more information on triggers, see the [Triggers Help Page](https://marketing
 
 Before setting up and using Adobe I/O, you will need to do the following:
 
-1. [Obtain product authorization](#obtainproductauthorization)
-2. [Obtain administrative permissions](#obtainadministrativepermissions)
+1. [Obtain product authorization](#obtain-product-authorization)
+2. [Obtain administrative permissions](#obtain-administrative-permissions)
 
 ### Obtain product authorization
 
@@ -48,8 +48,8 @@ If you do not have administrative permissions, please contact your Adobe System 
 
 To set up Analytics Triggers:
 
-1. [Get product access through Adobe Admin Console](#getproductaccessthroughadobeadminconsole)
-2. [Specify a new trigger](#specifyanewtrigger)
+1. [Get product access through Adobe Admin Console](#get-product-access-through-adobe-admin-console)
+2. [Specify a new trigger](#specify-a-new-trigger)
 
 #### Get product access through Adobe Admin Console	 
 

--- a/using/cc-asset-event-setup.md
+++ b/using/cc-asset-event-setup.md
@@ -115,13 +115,13 @@ Now you&rsquo;re ready to configure ngrok to serve your webhook over the interne
 
 
 ## Receive events
- Your integration is now set up, and your webhook is in place; but to receive events, your integration needs to connect to its event provider, Creative Cloud Assets, on behalf of its user. This requires authentication; see [OAuth Integration](https://www.adobe.io/apis/cloudplatform/console/authentication/oauth_workflow.html). 
+ Your integration is now set up, and your webhook is in place; but to receive events, your integration needs to connect to its event provider, Creative Cloud Assets, on behalf of its user. This requires authentication; see [OAuth Integration](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/AuthenticationOverview/OAuthIntegration.md). 
  
  Start with the Integration Overview. It&rsquo;s the screen you see immediately after selecting **Continue to Integration details**.
 
 ![Integration Overview](../img/events_cca_08.png "Integration Overview")
 
- For authentication setup, you&rsquo;ll need to add the [Creative SDK](https://www.adobe.io/apis/creativecloud/creativesdk/docs/websdk/adobe-creative-sdk-for-web_master/getting-started.html) as a service, and then use the [User Auth UI](https://www.adobe.io/apis/creativecloud/creativesdk/docs/websdk/adobe-creative-sdk-for-web_master/user-auth-ui.html) to build an interface for your user to log into your app and give your app authorization to access Creative Cloud Assets. 
+ For authentication setup, you&rsquo;ll need to add the [Creative SDK](https://www.adobe.io/apis/creativecloud/creativesdk/docs/websdk.html#!getting-started.md) as a service, and then use the [User Auth UI](https://www.adobe.io/apis/creativecloud/creativesdk/docs/websdk.html#!user-auth-ui.md) to build an interface for your user to log into your app and give your app authorization to access Creative Cloud Assets. 
 
  To add Creative SDK as a service:
  


### PR DESCRIPTION
This fixes the broken links in following pages -
1. [Setting Up Creative Cloud Asset Events on Adobe I/O Events](https://www.adobe.io/apis/experienceplatform/events/documentation.html#!adobedocs/adobeio-events/master/using/cc-asset-event-setup.md) page.
1.  [Integrate Analytics Triggers with Adobe I/O Events](https://www.adobe.io/apis/experienceplatform/events/documentation.html#!adobedocs/adobeio-events/master/using/analytics-triggers-event-setup.md) page.
1. [Setting up AEM Events with Adobe I/O Events](https://www.adobe.io/apis/experienceplatform/events/documentation.html#!adobedocs/adobeio-events/master/using/aem-event-setup.md) page
1. [Introduction to Adobe I/O Events Webhooks](https://www.adobe.io/apis/experienceplatform/events/documentation.html#!adobedocs/adobeio-events/master/intro/webhook_docs_intro.md) page

Also, as part of this PR, removed unnecessary information in _"Setting up AEM Events with Adobe I/O Events"_ page.

See below table for broken links in *"Setting Up Creative Cloud Asset Events on Adobe I/O Events"* page -

| Link Text | Broken Link | Fixed Link |
| --- | --- | --- |
| OAuth Integration | https://www.adobe.io/authentication/auth-methods.html#!adobeio/adobeio-documentation/master/auth/OAuth2.0Endponts/web-oauth2.0-guide.md | https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/AuthenticationOverview/OAuthIntegration.md |
| Creative SDK | https://www.adobe.io/apis/creativecloud/creativesdk/docs/websdk/adobe-creative-sdk-for-web_master/getting-started.html | https://www.adobe.io/apis/creativecloud/creativesdk/docs/websdk.html#!getting-started.md |
| User Auth UI | https://www.adobe.io/apis/creativecloud/creativesdk/docs/websdk/adobe-creative-sdk-for-web_master/user-auth-ui.html | https://www.adobe.io/apis/creativecloud/creativesdk/docs/websdk.html#!user-auth-ui.md |

For other pages, many internal links were broken which have been fixed.