### PR TITLE
Fix broken internal links

### DIFF
--- a/intro/events-api.md
+++ b/intro/events-api.md
@@ -2,14 +2,14 @@
 
 # Working with Events Using the Adobe I/O Management API
 
-- [Events API calls in the I/O Management API](#eventsapicallsintheadobeiomanagementapi)
-- [Calling APIs](#callingapis)
-- [API Specifications:](#apispecifications)
-    - [GET /events/organizations/{orgId}/integrations/{intId}/registrations](#get-all-regs)
-    - [POST /events/organizations/{orgId}/integrations/{intId}/registrations](#post-reg-webhook)
-    - [GET /events/organizations/{orgId}/integrations/{intId}/registrations/{registrationId}](#get-reg-details)
-    - [GET /events/organizations/{orgId}/integrations/{intId}/tracing/{registrationId}](#get-tracing)
-    - [GET /events/organizations/{orgId}/integrations/{intId}/{registrationId}](#get-journal)
+- [Events API calls in the I/O Management API](#Events-API-calls-in-the-Adobe-IO-Management-API)
+- [Calling APIs](#Calling-APIs)
+- [API Specifications](#API-Specifications)
+    - [`GET /events/organizations/{orgId}/integrations/{intId}/registrations`](#GET-eventsorganizationsorgIdintegrationsintIdregistrations)
+    - [`POST /events/organizations/{orgId}/integrations/{intId}/registrations`](#POST-eventsorganizationsorgIdintegrationsintIdregistrations)
+    - [`GET /events/organizations/{orgId}/integrations/{intId}/registrations/{registrationId}`](#GET-eventsorganizationsorgIdintegrationsintIdregistrationsregistrationId)
+    - [`GET /events/organizations/{orgId}/integrations/{intId}/tracing/{registrationId}`](#GET-eventsorganizationsorgIdintegrationsintIdtracingregistrationId)
+    - [`GET /events/organizations/{orgId}/integrations/{intId}/{registrationId}`](#GET-eventsorganizationsorgIdintegrationsintIdregistrationId)
 
 As an open system, Adobe Cloud Platform allows you access through APIs to just about any functionality you need. This includes events. The Adobe I/O Management API provides several API calls that enable you to manage events programmatically. 
 

--- a/support/debug.md
+++ b/support/debug.md
@@ -4,8 +4,8 @@
 
 This page captures the most common troubleshooting scenarios when working with Adobe Events. 
 
-* [AEM Events](#aemevents)
-* [Analytics Triggers Events](#analyticstriggersevents)
+* [AEM Events](#AEM-Events)
+* [Analytics Triggers Events](#Analytics-Triggers-Events)
 
 ## AEM Events
 

--- a/support/faq.md
+++ b/support/faq.md
@@ -2,9 +2,9 @@
 
 # Adobe I/O Events Frequently Asked Questions (FAQ)
 
-* [General questions](#generalquestions)
-* [AEM events](#aemevents)
-* [Analytics Triggers events](#analyticstriggersevents)
+* [General questions](#General-questions)
+* [AEM events](#AEM-events)
+* [Analytics Triggers events](#Analytics-Triggers-Events)
 
 ## General questions
 _**What are I/O Events?**_  

--- a/using/cc-asset-event-setup.md
+++ b/using/cc-asset-event-setup.md
@@ -3,10 +3,10 @@
 These instructions describe how to set up Creative Cloud Asset events using Adobe I/O Events. You can use Adobe I/O for notification of CC Asset events. 
 
 - [Introduction](#introduction)  
-- [Access events](#accessevents)  
-- [Create an integration](#createanintegration)  
-- [Receive events](#receiveevents)
-- [Adobe Consent API](#consentapi)
+- [Access events](#Access-events)  
+- [Create an integration](#Create-an-integration)  
+- [Receive events](#Receive-events)
+- [Adobe Consent API](#Adobe-Consent-API)
 
 ## Introduction
 Creative Cloud Assets provides a simple set of events to which you can subscribe: 


### PR DESCRIPTION
This fixes the broken internal links in following pages -
1. [Setting Up Creative Cloud Asset Events on Adobe I/O Events](https://www.adobe.io/apis/experienceplatform/events/documentation.html#!adobedocs/adobeio-events/master/using/cc-asset-event-setup.md).
1. [Working with Events Using the Adobe I/O Management API](https://www.adobe.io/apis/experienceplatform/events/documentation.html#!adobedocs/adobeio-events/master/intro/events-api.md)
1. [Adobe I/O Events Frequently Asked Questions (FAQ)
](https://www.adobe.io/apis/experienceplatform/events/documentation.html#!adobedocs/adobeio-events/master/support/faq.md)
1. [Debugging Adobe I/O Events](https://www.adobe.io/apis/experienceplatform/events/documentation.html#!adobedocs/adobeio-events/master/support/debug.md)