### PR TITLE
Fix internal linking navigation

### DIFF
--- a/intro/events-api.md
+++ b/intro/events-api.md
@@ -2,14 +2,14 @@
 
 # Working with Events Using the Adobe I/O Management API
 
-- [Events API calls in the I/O Management API](#Events-API-calls-in-the-Adobe-IO-Management-API)
-- [Calling APIs](#Calling-APIs)
-- [API Specifications](#API-Specifications)
-    - [`GET /events/organizations/{orgId}/integrations/{intId}/registrations`](#GET-eventsorganizationsorgIdintegrationsintIdregistrations)
-    - [`POST /events/organizations/{orgId}/integrations/{intId}/registrations`](#POST-eventsorganizationsorgIdintegrationsintIdregistrations)
-    - [`GET /events/organizations/{orgId}/integrations/{intId}/registrations/{registrationId}`](#GET-eventsorganizationsorgIdintegrationsintIdregistrationsregistrationId)
-    - [`GET /events/organizations/{orgId}/integrations/{intId}/tracing/{registrationId}`](#GET-eventsorganizationsorgIdintegrationsintIdtracingregistrationId)
-    - [`GET /events/organizations/{orgId}/integrations/{intId}/{registrationId}`](#GET-eventsorganizationsorgIdintegrationsintIdregistrationId)
+- [Events API calls in the I/O Management API](#events-api-calls-in-the-adobe-io-management-api)
+- [Calling APIs](#calling-apis)
+- [API Specifications:](#api-specifications)
+    - [GET /events/organizations/{orgId}/integrations/{intId}/registrations](#get-all-regs)
+    - [POST /events/organizations/{orgId}/integrations/{intId}/registrations](#post-reg-webhook)
+    - [GET /events/organizations/{orgId}/integrations/{intId}/registrations/{registrationId}](#get-reg-details)
+    - [GET /events/organizations/{orgId}/integrations/{intId}/tracing/{registrationId}](#get-tracing)
+    - [GET /events/organizations/{orgId}/integrations/{intId}/{registrationId}](#get-journal)
 
 As an open system, Adobe Cloud Platform allows you access through APIs to just about any functionality you need. This includes events. The Adobe I/O Management API provides several API calls that enable you to manage events programmatically. 
 

--- a/support/debug.md
+++ b/support/debug.md
@@ -4,8 +4,8 @@
 
 This page captures the most common troubleshooting scenarios when working with Adobe Events. 
 
-* [AEM Events](#AEM-Events)
-* [Analytics Triggers Events](#Analytics-Triggers-Events)
+* [AEM Events](#aem-events)
+* [Analytics Triggers Events](#analytics-triggers-events)
 
 ## AEM Events
 

--- a/support/faq.md
+++ b/support/faq.md
@@ -2,9 +2,9 @@
 
 # Adobe I/O Events Frequently Asked Questions (FAQ)
 
-* [General questions](#General-questions)
-* [AEM events](#AEM-events)
-* [Analytics Triggers events](#Analytics-Triggers-Events)
+* [General questions](#general-questions)
+* [AEM events](#aem-events)
+* [Analytics Triggers Events](#analytics-triggers-events)
 
 ## General questions
 _**What are I/O Events?**_  

--- a/using/aem-event-setup.md
+++ b/using/aem-event-setup.md
@@ -4,9 +4,9 @@
 
 These instructions describe how to set up Adobe Experience Manager (AEM) for Adobe I/O Events. You can use Adobe I/O for notification of AEM events, such as page or asset changes.
 
-- [Introduction](#introduction)  
-- [Setup products](#setup-products)  
-- [Use Adobe I/O](#use-adobe-io)  
+- [Introduction](#introduction)
+- [Setup Products](#setup-products)
+- [Use Adobe I/O](#use-adobe-io)
 - [Watch the solution work](#watch-the-solution-work)
 
 **Resources**
@@ -95,7 +95,7 @@ For more information, see AEM [User, Group and Access Rights Administration](htt
 To configure OAuth and IMS authentication:
 
 1. [Create a certificate and keystore](#create-a-certificate-and-keystore)
-2. [Add the certificate into the AEM eventproxy-service user's keystore](#Add-the-certificate-into-the-AEM-eventproxy-service-userrsquos-keystore)
+2. [Add the certificate into the AEM eventproxy-service user's keystore](#add-the-certificate-into-the-aem-eventproxy-service-userrsquos-keystore)
 3. [Configure the AEM Link Externalizer](#configure-the-aem-link-externalizer)
 
 #### Create a certificate and keystore
@@ -176,10 +176,10 @@ To configure AEM Link Externalizer:
 
 Use Adobe I/O to do the following:
 
-1. [Create an Adobe I/O Console integration](#Create-an-Adobe-IO-Console-integration)
-2. [Configure Adobe I/O Events as a cloud service in AEM](#AEM-Adobe-IO-Events-configuration)
-3. [Perform an AEM health and configuration check](#Perform-AEM-health-check)
-4. [Register the AEM event consumer app](#Register-the-AEM-event-consumer-app)
+1. [Create an Adobe I/O Console integration](#create-an-adobe-io-console-integration)
+2. [Configure Adobe I/O Events as a cloud service in AEM](#aem-adobe-io-events-configuration)
+3. [Perform an AEM health and configuration check](#perform-aem-health-check)
+4. [Register the AEM event consumer app](#register-the-aem-event-consumer-app)
 
 ### Create an Adobe I/O Console integration
 
@@ -304,9 +304,9 @@ module.exports = Webtask.fromExpress(app);
 
 You can watch the solution work by testing your integration. To do this:
 
-1. [Register your webhook with the Adobe I/O Console](#Register-your-webhook-with-the-Adobe-IO-Console)
-2. [Perform a webhook health check](#Perform-a-webhook-health-check)
-3. [Optional: Adobe I/O Events OSGI to XDM event mapping configurations](#Adobe-IO-Events-OSGI-to-XDM-event-mapping-configurations)
+1. [Register your webhook with the Adobe I/O Console](#register-your-webhook-with-the-adobe-io-console)
+2. [Perform a webhook health check](#perform-a-webhook-health-check)
+3. [Optional: Adobe I/O Events OSGI to XDM event mapping configurations](#adobe-io-events-osgi-to-xdm-event-mapping-configurations)
 
 ### Register your webhook with the Adobe I/O Console
 
@@ -318,13 +318,13 @@ Once you have your webhook ready, use the [Adobe I/O Console](https://adobe.io/c
 
       ![Receive near real-time events](../img/events_aem_24.png "Receive near real-time events")
 
-3. Select the AEM Link Externalizer base URL that you [previously specified](#Configure-the-AEM-Link-Externalizer) and then select **Continue**.
+3. Select the AEM Link Externalizer base URL that you [previously specified](#configure-the-aem-link-externalizer) and then select **Continue**.
 
       ![AEM Externalizer base URL on Marketing Cloud](../img/events_aem_25.png "AEM Externalizer base URL on Marketing Cloud")
 
       >**Note:** If you do not see your instance, follow the below part: [Perform AEM health check](#perform-aem-health-check)
 
-4. Select **Create new integration** and fill in the **Integration Details** form [similar to your previous integration](#Create-new-integration-box).
+4. Select **Create new integration** and fill in the **Integration Details** form [similar to your previous integration](#create-an-adobe-io-console-integration).
 
 5. Select **Add webhook** and complete the **Add a new webhook** form.
 

--- a/using/cc-asset-event-setup.md
+++ b/using/cc-asset-event-setup.md
@@ -2,11 +2,11 @@
 
 These instructions describe how to set up Creative Cloud Asset events using Adobe I/O Events. You can use Adobe I/O for notification of CC Asset events. 
 
-- [Introduction](#introduction)  
-- [Access events](#Access-events)  
-- [Create an integration](#Create-an-integration)  
-- [Receive events](#Receive-events)
-- [Adobe Consent API](#Adobe-Consent-API)
+- [Introduction](#introduction)
+- [Access events](#access-events)
+- [Create an integration](#create-an-integration)
+- [Receive events](#receive-events)
+- [Adobe Consent API](#adobe-consent-api)
 
 ## Introduction
 Creative Cloud Assets provides a simple set of events to which you can subscribe: 


### PR DESCRIPTION
Internal link navigation was not working because of target link ids not being entirely in lowercase. This PR fixes that for the affected files.