### PR TITLE
Fixing manifest order and using link

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -90,16 +90,16 @@
           "title": "Adobe Experience Platform Events"
         },
         {
-          "importedFileName": "marketo-user-audit-data-stream-setup",
-          "pages": [],
-          "path": "adobedocs/adobeio-events/stage/using/marketo-user-audit-data-stream-setup.md",
-          "title": "Marketo User Audit Data Stream"
-        },
-        {
           "importedFileName": "privacy-event-setup",
           "pages": [ ],
           "path": "adobedocs/adobeio-events/stage/using/privacy-event-setup.md",
           "title": "Privacy Events"
+        },
+        {
+          "importedFileName": "marketo-user-audit-data-stream-setup",
+          "pages": [],
+          "path": "adobedocs/adobeio-events/stage/using/marketo-user-audit-data-stream-setup.md",
+          "title": "Marketo User Audit Data Stream"
         }
       ],
       "path": "adobedocs/adobeio-events/stage/using.md",

--- a/using.md
+++ b/using.md
@@ -14,7 +14,7 @@ Setting up an integration to subscribe to Adobe I/O Events is straightforward. T
 * [Cloud Manager Events](https://www.adobe.io/apis/experiencecloud/cloud-manager/docs.html#!AdobeDocs/cloudmanager-api-docs/master/create-event-integration.md)
 * [Adobe Experience Platform Events](using/experience-platform-event-setup.md)
 * [Privacy Events](using/privacy-event-setup.md)
-* [Marketo Events](/using/marketo-user-audit-data-stream-setup.md)
+* [Marketo User Audit Data Stream](using/marketo-user-audit-data-stream-setup.md)
 
 
 <!-- - [Adobe Stock](using/adobe-stock-event-setup.md) -->


### PR DESCRIPTION
Noticed that the link on the using.md page for Marketo events had a small bug and updating the order of pages in the manifest to keep Marketo at the end for now.