### PR TITLE
Fix Shared Cloud Asset Events external facing documentation to incorporate "Creative SDK" service removal from Console

### DIFF
--- a/using/cc-asset-event-setup.md
+++ b/using/cc-asset-event-setup.md
@@ -94,9 +94,9 @@ For more information, read the [Introduction to Webhooks](../intro/webhook_docs_
 
 Your integration is now set up, and your webhook is in place; but to receive events, your integration needs to connect to its event provider, Creative Cloud Assets, on behalf of its user. This requires authentication; see [OAuth Integration](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/AuthenticationOverview/OAuthIntegration.md). 
 
-For authentication setup, you&rsquo;ll need to add the Creative SDK as a service, and then use the [OAuth 2.0 protocol](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/OAuth/OAuth.md) to build an interface for your user to log into your app and give your app authorization to access Creative Cloud Assets. 
+For authentication setup, you&rsquo;ll need to add the Creative Cloud Libraries as a service, and then use the [OAuth 2.0 protocol](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/OAuth/OAuth.md) to build an interface for your user to log into your app and give your app authorization to access Creative Cloud Assets. 
 
-To add Creative SDK as a service, you will need to follow the steps for [adding an API that uses OAuth to a Console project](https://www.adobe.io/apis/experienceplatform/console/docs.html#!AdobeDocs/adobeio-console/master/services-add-api-oauth.md), being sure to select **Creative SDK** from the list of available APIs.
+To add Creative Cloud Libraries as a service, you will need to follow the steps for [adding an API that uses OAuth to a Console project](https://www.adobe.io/apis/experienceplatform/console/docs.html#!AdobeDocs/adobeio-console/master/services-add-api-oauth.md), being sure to select **Creative Cloud Libraries** from the list of available APIs.
  
 Adobe OAuth 2.0 lets you build into your application a login function that takes the user&rsquo;s Adobe ID and lets the user give your app permission to access the assets and Adobe Solutions to which they&rsquo;re subscribed. Once your app is authenticated, Adobe will begin to push events to your integration&rsquo;s webhook via HTTP POST messages.
 

--- a/using/cc-asset-event-setup.md
+++ b/using/cc-asset-event-setup.md
@@ -4,7 +4,7 @@ These instructions describe how to set up Creative Cloud Asset events using Adob
 
 - [Introduction](#introduction)
 - [Access events](#access-events)
-- [Create an integration](#create-an-integration)
+- [Create a project in Adobe Developer Console](#create-a-project-in-adobe-developer-console)
 - [Receive events](#receive-events)
 - [Adobe Consent API](#adobe-consent-api)
 


### PR DESCRIPTION
## Description
- Changing "Creative SDK" service to "Creative Cloud Libraries" API everywhere in the documentation
- Also fixed a TOC link

## Note
Please **note** that this PR has been raised against `stage` branch and not `master` branch as this change is not live in console's prod environment yet.