### PR TITLE
Fixing manifest for registration api documentation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -183,7 +183,7 @@
         {
           "importedFileName": "registration_api",
           "pages": [],
-          "path": "adobedocs/adobeio-events/master/support/registration_api.md",
+          "path": "adobedocs/adobeio-events/master/api/registration_api.md",
           "title": "Registration API"
         }
       ]


### PR DESCRIPTION
## Description
This PR fixes the manifest for registration api documentation. Currently the link is [broken](https://www.adobe.io/apis/experienceplatform/events/docs.html#!adobedocs/adobeio-events/master/support/registration_api.md) in our public facing [documentation](https://www.adobe.io/apis/experienceplatform/events/docs.html#!adobedocs/adobeio-events/master/api/api.md).

## Note
Please **note** that this PR has been raised against `master` branch.