### PR TITLE
Fix links for navigation in custom events doc

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Description
+This PR makes the following changes -
+ - _A few words describing the overall changes done._
+
+## Note
+PR raised against which branch -
+ - [ ] master (Production)
+ - [ ] stage (Stage)

--- a/using/custom_events.md
+++ b/using/custom_events.md
@@ -22,6 +22,6 @@ Build custom apps that interact with core Adobe services, and automate processes
 
 Register your custom Adobe I/O Events providers and associated event metadata, create event based registrations, 
 and then  start registering your apps as providers, using either
-* [Adobe I/O Events API](api/api.md)  
-* [Adobe I/O Events CLI](cli/cli.md) 
-* [Adobe I/O Events SDK](sdk/sdk.md) 
+* [Adobe I/O Events API](../api/api.md)  
+* [Adobe I/O Events CLI](../cli/cli.md) 
+* [Adobe I/O Events SDK](../sdk/sdk.md) 


### PR DESCRIPTION
## Description
This PR makes the following changes -
 - Fixed links for navigation in the custom event [documentation](https://www.adobe.io/apis/experienceplatform/events/docs.html#!adobedocs/adobeio-events/master/using/custom_events.md).
 - Added a pull request template.
 
## Note
PR raised against which branch -
 - [x] master (Production)
 - [ ] stage (Stage)